### PR TITLE
Use env shebang when possible.

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys

--- a/metrics.py
+++ b/metrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 from collections import namedtuple

--- a/particlefilter.py
+++ b/particlefilter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # coding=utf8
 
 import numpy

--- a/spotsfinder.py
+++ b/spotsfinder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # coding=utf8
 
 

--- a/spotstracker.py
+++ b/spotstracker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # coding=utf8
 
 

--- a/test_spotstracker.py
+++ b/test_spotstracker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # coding=utf8
 
 from spotstracker import *

--- a/viewer/metrics.py
+++ b/viewer/metrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 # Distance values are in meters

--- a/viewer/objlib.py
+++ b/viewer/objlib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import os

--- a/viewer/viewer.py
+++ b/viewer/viewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys

--- a/web/data.py
+++ b/web/data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import math

--- a/web/feeder.py
+++ b/web/feeder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys

--- a/web/flush_table.py
+++ b/web/flush_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys

--- a/web/insert.py
+++ b/web/insert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding:utf-8 -*-
 
 import sys

--- a/web/web.py
+++ b/web/web.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import threading


### PR DESCRIPTION
Use `#!/usr/bin/env python2` shebang instead of `#!/usr/bin/python`
to be more flexible in python's location, and to allow for the use
of a virtualenv.